### PR TITLE
setCharacter, Sanji doesn't inherit monobehavior

### DIFF
--- a/Assets/PlayerMovement.cs
+++ b/Assets/PlayerMovement.cs
@@ -33,10 +33,7 @@ public class PlayerMovement : MonoBehaviour {
 		jumpdelta = 0;
 		anim = GetComponent<Animator>();
 		right = true;
-		hitboxmanager = this.gameObject.GetComponentInChildren<HitBoxManager> ();
-
-		// THIS NEEDS TO BE PART OF PLAYER SPAWNER!!!! Hacky for now, as I branched from develop before player spawner ):
-		character = new Sanji (); 
+		hitboxmanager = this.gameObject.GetComponentInChildren<HitBoxManager> (); 
 		thrown = false;
 	}
 
@@ -54,6 +51,11 @@ public class PlayerMovement : MonoBehaviour {
 			VERTICAL = "Vertical2";
 			break;
 		}
+	}
+
+	// set character
+	public void setCharacter(Character character) {
+		this.character = character;
 	}
 	
 	// Update is called once per frame

--- a/Assets/PlayerSpawner.cs
+++ b/Assets/PlayerSpawner.cs
@@ -11,8 +11,11 @@ public class PlayerSpawner : MonoBehaviour {
 		// also need to determine spawn positions x,y. Could just input to this script based on scene?
 		GameObject player1 = Instantiate (sanji, new Vector2 (3, -3), Quaternion.identity) as GameObject;
 		GameObject player2 = Instantiate (sanji, new Vector2 (-3, -3), Quaternion.identity) as GameObject;
+		// set player specific settings
 		player1.GetComponent<PlayerMovement>().setPlayer (1);
 		player2.GetComponent<PlayerMovement>().setPlayer (2);
+		player1.GetComponent<PlayerMovement> ().setCharacter (new Sanji ());
+		player2.GetComponent<PlayerMovement> ().setCharacter (new Sanji ());
 	}
 	
 	// Update is called once per frame

--- a/Assets/Sanji.cs
+++ b/Assets/Sanji.cs
@@ -1,17 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class Sanji : MonoBehaviour, Character {
-
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
-	}
+public class Sanji : Character {
 
 	public void kick(GameObject collider, GameObject hitter) {
 		// here we would apply damage unique to Sanji's kick
@@ -20,4 +10,5 @@ public class Sanji : MonoBehaviour, Character {
 		// everything for now though.
 		collider.GetComponent<PlayerMovement>().wasThrown (hitter.transform.position.x - collider.transform.position.x);
 	}
+
 }


### PR DESCRIPTION
moved character setting into PlayerSpawner, which sets the character to Sanji by PlayerMovement.setCharacter(Character character). Also changed Sanji to no longer inherit MonoBehavior as it is not a script. Unity was complaining about the fact I was instantiating a MonoBehavior through new Object() style construction instead of adding it as a component, but as it is not supposed to be a component, I simply made it not a MonoBehavior.
