### PR TITLE
add knockback based on kick

### DIFF
--- a/Assets/PlayerMovement.cs
+++ b/Assets/PlayerMovement.cs
@@ -15,12 +15,15 @@ public class PlayerMovement : MonoBehaviour {
 	public bool right;
 	public bool thrown;
 	public bool thrownright;
+	public Vector2 knockbackVector;
 	public HitBoxManager hitboxmanager;
 
 	public Character character;
 	
 	public string HORIZONTAL;
 	public string VERTICAL;
+
+	public const float GRAVITY = -.05f;
 
 	// Use this for initialization
 	void Start () {
@@ -77,16 +80,16 @@ public class PlayerMovement : MonoBehaviour {
 			// from every other animation to thrown would be annoying. Thrown default returns to idle, for now.
 			anim.Play ("thrown");
 			thrown = false;
+			jumps = 1;
 		}
 
 		// Special Animation logic
 
 		// if thrown, ignore user input, velocity is away from the direction you are facing.
 		if (anim.GetCurrentAnimatorStateInfo (0).IsName ("thrown")) {
-			if(right)
-				xvelocity = -1f;
-			else
-				xvelocity = 1f;
+			xvelocity = knockbackVector.x;
+			yvelocity = knockbackVector.y;
+			knockbackVector.y -= GRAVITY;
 		}
 		// if kicking, ignore user input, don't move
 		else if (anim.GetCurrentAnimatorStateInfo (0).IsName ("kick")) {
@@ -151,9 +154,7 @@ public class PlayerMovement : MonoBehaviour {
 		}
 
 		// start character falling. Default falling felt bad. This is not necessary.
-		if (jumps > 0) {
-			yvelocity -= .05f;
-		}
+		yvelocity -= GRAVITY;
 
 		// apply movement
 		GetComponent<Rigidbody2D>().velocity = new Vector2(xvelocity, yvelocity) * Time.deltaTime * speed;
@@ -168,7 +169,9 @@ public class PlayerMovement : MonoBehaviour {
 	}
 	
 	void OnCollisionStay2D(Collision2D collision) {
-		
+		if (jumps == 0) {
+			yvelocity = 0;
+		}
 	}
 	
 	void OnCollisionExit2D(Collision2D collision) {
@@ -198,7 +201,7 @@ public class PlayerMovement : MonoBehaviour {
 	
 	public void wasThrown(float direction) {
 		// set direction to face your attacker and play thrown animation
-		if (direction > 0f) {
+		if (direction > 0) {
 			thrownright = true;
 		}
 		else {

--- a/Assets/Sanji.cs
+++ b/Assets/Sanji.cs
@@ -8,7 +8,11 @@ public class Sanji : Character {
 		// I think we should also apply the movement vector here for the collider, current implementation is actually quite bad
 		// as the collider sets its own direction, which has nothing to do with what hit it. Didn't want to go too far on changing
 		// everything for now though.
-		collider.GetComponent<PlayerMovement>().wasThrown (hitter.transform.position.x - collider.transform.position.x);
+		PlayerMovement player = collider.GetComponent<PlayerMovement> ();
+		float direction = hitter.transform.position.x - collider.transform.position.x;
+
+		player.knockbackVector = new Vector2 (direction > 0 ? -1 : 1, 1);
+		player.wasThrown (direction);
 	}
 
 }


### PR DESCRIPTION
Branch for issue #14 
Knockback vector is set in Sanji.kick(). This vector is then used by the player to determine where he goes during knockback.

Made a few small adjustments to gravity physics as well to make this work. Note that knockback also sets the players jump to one. This is in part to avoid a physics problem due to how I am stopping gravity when on a surface, but is also conveniently also a feature of smash (you get one ground jump and one air jump. Being launched into the air then gives 1 air jump, not two).

Description of the physics problem: If jumps = 0 and you try to leave a box, your yvelocity is getting set to 0 due to the "onCollisionStay2D". I avoided this by just not using onCollisionStay2D and having gravity stop when jumps = 0, which of course had its own repercussions. Now gravity is always going, but so long as you are colliding with the floor, it gets set back to 0. Sticking to walls will still be a thing we need to work out at some point, but we also currently don't have any walls to stick to. I'll make an issue noting that. I could give a better description in person, but there is some annoying problems with the order of methods being called that makes escaping the onCollisionStay2D a bit of a pain.
