### PR TITLE
improve raycasting and physics

### DIFF
--- a/Assets/PlayerMovement.cs
+++ b/Assets/PlayerMovement.cs
@@ -183,13 +183,17 @@ public class PlayerMovement : MonoBehaviour {
 
 		// if you want to see the raycast that determines whether this player can jump
 		// or not, turn on Gizmos in the game view
-		Debug.DrawRay (transform.position, Vector2.down * raycastJumpLength, Color.red);
+		Debug.DrawRay (new Vector2(GetComponent<BoxCollider2D>().bounds.center.x, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down * raycastJumpLength, Color.red);
+		Debug.DrawRay (new Vector2(GetComponent<BoxCollider2D>().bounds.max.x - .01f, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down * raycastJumpLength, Color.red);
+		Debug.DrawRay (new Vector2(GetComponent<BoxCollider2D>().bounds.min.x + .01f, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down * raycastJumpLength, Color.red);
 	}
-	
+
 	void OnCollisionEnter2D(Collision2D collision) {
-		RaycastHit2D raycastJump = Physics2D.Raycast (transform.position, Vector2.down, raycastJumpLength);
+		RaycastHit2D raycastBottomMiddle = Physics2D.Raycast (new Vector2(GetComponent<BoxCollider2D>().bounds.center.x, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down, raycastJumpLength);
+		RaycastHit2D raycastBottomRight = Physics2D.Raycast (new Vector2(GetComponent<BoxCollider2D>().bounds.max.x - .01f, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down, raycastJumpLength);
+		RaycastHit2D raycastBottomLeft = Physics2D.Raycast (new Vector2(GetComponent<BoxCollider2D>().bounds.min.x + .01f, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down, raycastJumpLength);
 		// if the player can jump on something
-		if (raycastJump.collider != null) {
+		if (raycastBottomMiddle.collider != null || raycastBottomRight.collider != null || raycastBottomLeft.collider != null) {
 			jumps = 0;
 			yvelocity = 0;
 		}
@@ -202,9 +206,11 @@ public class PlayerMovement : MonoBehaviour {
 	}
 	
 	void OnCollisionExit2D(Collision2D collision) {
-		RaycastHit2D raycastJump = Physics2D.Raycast (transform.position, Vector2.down, raycastJumpLength);
+		RaycastHit2D raycastBottomMiddle = Physics2D.Raycast (new Vector2(GetComponent<BoxCollider2D>().bounds.center.x, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down, raycastJumpLength);
+		RaycastHit2D raycastBottomRight = Physics2D.Raycast (new Vector2(GetComponent<BoxCollider2D>().bounds.max.x - .01f, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down, raycastJumpLength);
+		RaycastHit2D raycastBottomLeft = Physics2D.Raycast (new Vector2(GetComponent<BoxCollider2D>().bounds.min.x + .01f, GetComponent<BoxCollider2D>().bounds.min.y - .01f), Vector2.down, raycastJumpLength);
 		// if the player can jump on something
-		if (raycastJump.collider != null) {
+		if (raycastBottomMiddle.collider == null && raycastBottomRight.collider == null && raycastBottomLeft.collider == null) {
 			jumps = 1;
 		}
 	}


### PR DESCRIPTION
- Added extra raycasts (bottom left and bottom right of box), also changed origin vectors to be based on the collision box itself.
- Rays were moved slightly down to avoid hitting the player it was for.
- Fixed OnCollisionExit2D to set jumps = 1 when colliders ARE null (nothing below the player), not when colliders are NOT null (there is something below the player).

I would like to have the ray vectors be somehow more abstracted, they seem repetitive in a lot of values, but they might also be one off's and not a big deal (if we change the size of the physics box now the rays should follow. Though if we add a frame by frame physics boxes, we might need to adjust the code a bit).

Should fix #41 and #42.
